### PR TITLE
Gahtc 346

### DIFF
--- a/gahtc/mapbuilder/static/mapbuilder/css/main.css
+++ b/gahtc/mapbuilder/static/mapbuilder/css/main.css
@@ -726,9 +726,6 @@ input[type="range"] {
     display: none;
 }
 
-#opacity:hover .slider-container {
-    display: block;
-}
 
 .toolbar-icon-dropdown li {
     padding: 5px 20px;

--- a/gahtc/mapbuilder/static/mapbuilder/js/draw.js
+++ b/gahtc/mapbuilder/static/mapbuilder/js/draw.js
@@ -594,15 +594,15 @@ function mapbuilderShapeFormattingEventHandlers() {
         input.value = objectOpacity * 100
         // console.log('object opacity-->', canvasF.getActiveObject().opacity);
         // console.log('opacity slider value-->', input.value)
-
+        $(document).mouseup(function(e) {
+            var container = $(".slider-container");
+            if (!container.is(e.target) && container.has(e.target).length === 0) 
+           {
+               container.hide();
+           }
+        });
     })
-    $(document).mouseup(function(e) {
-     var container = $(".slider-container");
-     if (!container.is(e.target) && container.has(e.target).length === 0) 
-    {
-        container.hide();
-    }
-    });
+    
 
 
     $('.opacity-slider').change(function (){

--- a/gahtc/mapbuilder/static/mapbuilder/js/draw.js
+++ b/gahtc/mapbuilder/static/mapbuilder/js/draw.js
@@ -3,6 +3,9 @@ var canvasF;
 const layerId = localStorage.getItem('layerId');
 const zoom = localStorage.getItem('zoom');
 const mapBound = JSON.parse(localStorage.getItem('bounds'));
+const mapBoxAttribution = 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributor' +
+'s, <a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, Imager' +
+'y © <a href="http://mapbox.com">Mapbox</a>'
 var mapBounds;
 if(mapBound) {
     const southWest = [
@@ -49,15 +52,22 @@ function intializeMap() {
         maxBounds: mapBounds,
         preferCanvas: true
     }).on('load', function () {
-        const tileLayer = L
+        if (layerId == 'mapbox.light' || layerId == 'mapbox.satellite'){
+            tileLayer = L
             .tileLayer('https://api.tiles.mapbox.com/v4/{id}/{z}/{x}/{y}.png?access_token={accessToken}', {
-                attribution: 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributor' +
-                's, <a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, Imager' +
-                'y © <a href="http://mapbox.com">Mapbox</a>',
+                attribution: mapBoxAttribution,
                 id: layerId,
                 accessToken: window.MAPBOX_ACCESS_TOKEN
             })
             .addTo(map);
+        } else {
+            tileLayer = L.tileLayer('https://api.mapbox.com/styles/v1/nijeldev/cjh1t3o2l08ao2snw8gljsp5q/tiles/256/{z}/{x}/{y}?access_token=pk.eyJ1IjoibmlqZWxkZXYiLCJhIjoiY2pmMWRpdW93MDJnbTJ4bXE0YTA1amZmdSJ9.bmSlHYHyP5zaIwuKJtPjPQ', {
+                attribution: mapBoxAttribution,
+                id: 'cjhgodu8f4x4p2smizw2o0btn',
+                accessToken: window.MAPBOX_ACCESS_TOKEN
+            }).addTo(map)
+        }
+        
         tileLayer.on('load', function () {
 
             leafletImage(map, function (err, canvas) {

--- a/gahtc/mapbuilder/static/mapbuilder/js/draw.js
+++ b/gahtc/mapbuilder/static/mapbuilder/js/draw.js
@@ -171,7 +171,6 @@ function mapbuilderShapeEventHandlers() {
         });
 
     $("#rect").click(function () {
-
         removeEvents();
         changeObjectSelection(false);
 
@@ -485,6 +484,7 @@ function mapbuilderShapeEventHandlers() {
         var alltogetherObj = new fabric.Group(objs);
         canvasF.add(alltogetherObj);
     });
+    
 }
 
 function mapbuilderFontFormattingEventHandlers() {
@@ -564,6 +564,16 @@ function mapbuilderShapeFormattingEventHandlers() {
 
     $(".delete-shape-icon").on("click", function () {
         canvasF.remove(canvasF.getActiveObject());
+        var objects = canvasF.getObjects();
+        var objectsCount=canvasF.getObjects().length;
+        var notTextObjectCount = 0;
+    
+        if (objectsCount === 0) {
+            $('.edit-icons,.format-icons ').css({'pointer-events': 'none', 'background': '#d2d2d2'});
+        }
+        if (canvasF.getObjects("i-text").length === 0) {
+                $('.format-icons ').css({'pointer-events': 'none', 'background': '#d2d2d2'});
+        }
     });
 
     $(".stroke-style-option").on("click", function () {
@@ -592,8 +602,6 @@ function mapbuilderShapeFormattingEventHandlers() {
         var objectOpacity = canvasF.getActiveObject().opacity
         var input = document.getElementById('opacitySlider')
         input.value = objectOpacity * 100
-        // console.log('object opacity-->', canvasF.getActiveObject().opacity);
-        // console.log('opacity slider value-->', input.value)
         $(document).mouseup(function(e) {
             var container = $(".slider-container");
             if (!container.is(e.target) && container.has(e.target).length === 0) 
@@ -844,6 +852,7 @@ function updateCanvasWithExistingMap() {
 
 $(document).ready(function () {
     initializeFabric();
+    
     // console.log(currentMapJson, currentMapImage);
     if (mapId === "" || mapId === "False"  || mapId === false) {
         intializeMap();
@@ -861,8 +870,16 @@ $(document).ready(function () {
         .keyup(function (e) {
             if (e.keyCode == 8 && canvasF.getActiveObject().get('type')!=="i-text") {
                 canvasF.remove(canvasF.getActiveObject());
+                console.log(canvasF.getObjects().length)
+                console.log(canvasF.getObjects("i-text").length)
+                if (canvasF.getObjects().length === 0) {
+                $('.edit-icons,.format-icons ').css({'pointer-events': 'none', 'background': '#d2d2d2'});
+                } else if (canvasF.getObjects("i-text").length === 0 && canvasF.getObjects().length !== 0 ){
+                    $('.format-icons ').css({'pointer-events': 'none', 'background': '#d2d2d2'});
+                }
             }
         });
+    
     // disable event handling
     $('.edit-icons,.format-icons ').css('pointer-events', 'none');
 

--- a/gahtc/mapbuilder/static/mapbuilder/js/draw.js
+++ b/gahtc/mapbuilder/static/mapbuilder/js/draw.js
@@ -3,9 +3,6 @@ var canvasF;
 const layerId = localStorage.getItem('layerId');
 const zoom = localStorage.getItem('zoom');
 const mapBound = JSON.parse(localStorage.getItem('bounds'));
-const mapBoxAttribution = 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributor' +
-'s, <a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, Imager' +
-'y © <a href="http://mapbox.com">Mapbox</a>'
 var mapBounds;
 if(mapBound) {
     const southWest = [
@@ -52,22 +49,15 @@ function intializeMap() {
         maxBounds: mapBounds,
         preferCanvas: true
     }).on('load', function () {
-        if (layerId == 'mapbox.light' || layerId == 'mapbox.satellite'){
-            tileLayer = L
+        const tileLayer = L
             .tileLayer('https://api.tiles.mapbox.com/v4/{id}/{z}/{x}/{y}.png?access_token={accessToken}', {
-                attribution: mapBoxAttribution,
+                attribution: 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributor' +
+                's, <a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, Imager' +
+                'y © <a href="http://mapbox.com">Mapbox</a>',
                 id: layerId,
                 accessToken: window.MAPBOX_ACCESS_TOKEN
             })
             .addTo(map);
-        } else {
-            tileLayer = L.tileLayer('https://api.mapbox.com/styles/v1/nijeldev/cjh1t3o2l08ao2snw8gljsp5q/tiles/256/{z}/{x}/{y}?access_token=pk.eyJ1IjoibmlqZWxkZXYiLCJhIjoiY2pmMWRpdW93MDJnbTJ4bXE0YTA1amZmdSJ9.bmSlHYHyP5zaIwuKJtPjPQ', {
-                attribution: mapBoxAttribution,
-                id: 'cjhgodu8f4x4p2smizw2o0btn',
-                accessToken: window.MAPBOX_ACCESS_TOKEN
-            }).addTo(map)
-        }
-        
         tileLayer.on('load', function () {
 
             leafletImage(map, function (err, canvas) {
@@ -564,16 +554,7 @@ function mapbuilderShapeFormattingEventHandlers() {
 
     $(".delete-shape-icon").on("click", function () {
         canvasF.remove(canvasF.getActiveObject());
-        var objects = canvasF.getObjects();
-        var objectsCount=canvasF.getObjects().length;
-        var notTextObjectCount = 0;
-    
-        if (objectsCount === 0) {
-            $('.edit-icons,.format-icons ').css({'pointer-events': 'none', 'background': '#d2d2d2'});
-        }
-        if (canvasF.getObjects("i-text").length === 0) {
-                $('.format-icons ').css({'pointer-events': 'none', 'background': '#d2d2d2'});
-        }
+        disableToolbars();
     });
 
     $(".stroke-style-option").on("click", function () {
@@ -765,6 +746,19 @@ function mapActionHandlers() {
 
 }
 
+function disableToolbars(){
+    var objects = canvasF.getObjects();
+    var objectsCount=canvasF.getObjects().length;
+    var notTextObjectCount = 0;
+
+    if (objectsCount === 0) {
+        $('.edit-icons,.format-icons ').css({'pointer-events': 'none', 'background': '#d2d2d2'});
+    }
+    if (canvasF.getObjects("i-text").length === 0) {
+            $('.format-icons ').css({'pointer-events': 'none', 'background': '#d2d2d2'});
+    }
+}
+
 function dataURLtoBlob(dataurl) {
     var arr = dataurl.split(','), mime = arr[0].match(/:(.*?);/)[1],
         bstr = atob(arr[1]), n = bstr.length, u8arr = new Uint8Array(n);
@@ -870,13 +864,7 @@ $(document).ready(function () {
         .keyup(function (e) {
             if (e.keyCode == 8 && canvasF.getActiveObject().get('type')!=="i-text") {
                 canvasF.remove(canvasF.getActiveObject());
-                console.log(canvasF.getObjects().length)
-                console.log(canvasF.getObjects("i-text").length)
-                if (canvasF.getObjects().length === 0) {
-                $('.edit-icons,.format-icons ').css({'pointer-events': 'none', 'background': '#d2d2d2'});
-                } else if (canvasF.getObjects("i-text").length === 0 && canvasF.getObjects().length !== 0 ){
-                    $('.format-icons ').css({'pointer-events': 'none', 'background': '#d2d2d2'});
-                }
+                disableToolbars()
             }
         });
     

--- a/gahtc/mapbuilder/static/mapbuilder/js/draw.js
+++ b/gahtc/mapbuilder/static/mapbuilder/js/draw.js
@@ -193,7 +193,8 @@ function mapbuilderShapeEventHandlers() {
                 selectable: true,
                 fill: "rgba(233,116,81,0.5)",
                 stroke: 'black',
-                transparentCorners: false
+                transparentCorners: false,
+                opacity: 0.5
             });
             canvasF.add(rect);
         });
@@ -249,7 +250,8 @@ function mapbuilderShapeEventHandlers() {
                 stroke: 'black',
                 selectable: true,
                 originX: 'center',
-                originY: 'center'
+                originY: 'center',
+                opacity: 0.5
             });
             canvasF.add(circle);
         });
@@ -407,7 +409,8 @@ function mapbuilderShapeEventHandlers() {
                 top: top,
                 fill: "rgba(233,116,81,0.5)",
                 stroke: "black",
-                strokeWidth: 3
+                strokeWidth: 3,
+                opacity: 0.5
             });
         }
     });
@@ -583,6 +586,25 @@ function mapbuilderShapeFormattingEventHandlers() {
         }
         canvasF.renderAll();
     });
+
+    $('#opacity').click(function (e){
+        $('.slider-container').css('display','block')
+        var objectOpacity = canvasF.getActiveObject().opacity
+        var input = document.getElementById('opacitySlider')
+        input.value = objectOpacity * 100
+        // console.log('object opacity-->', canvasF.getActiveObject().opacity);
+        // console.log('opacity slider value-->', input.value)
+
+    })
+    $(document).mouseup(function(e) {
+     var container = $(".slider-container");
+     if (!container.is(e.target) && container.has(e.target).length === 0) 
+    {
+        container.hide();
+    }
+    });
+
+
     $('.opacity-slider').change(function (){
         var opacity = $(".opacity-slider").val();
         opacity = opacity / 100;

--- a/gahtc/mapbuilder/templates/mapbuilder/map-export.html
+++ b/gahtc/mapbuilder/templates/mapbuilder/map-export.html
@@ -94,8 +94,8 @@
         </a>
         <a class="toolbar-icon"  id="opacity">
             <img src="{% static 'mapbuilder/css/images/opacity.svg'%}" alt="">
-            <div class="slider-container">
-                <input class="opacity-slider" type="range" max="100" min="0" step="1" value="50">
+            <div class="slider-container ">
+                <input class="opacity-slider" id='opacitySlider' type="range" max="100" min="0" step="1">
             </div>
             <span class="tooltip">
                 Opacity

--- a/gahtc/mapbuilder/templates/mapbuilder/map-extent.html
+++ b/gahtc/mapbuilder/templates/mapbuilder/map-extent.html
@@ -42,7 +42,7 @@
     $(document).ready(function () {
         if (layerId == 'mapbox.light') {
             $("#btn2").trigger('click');
-        } else if (layerId == 'terrain') {
+        } else if (layerId == 'mapbox.emarald') {
             $("#btn1").trigger('click');
         } else if (layerId == 'mapbox.satellite') {
             $("#btn3").trigger('click');
@@ -67,11 +67,12 @@
             id: 'mapbox.light',
             accessToken: '{{ MAPBOX_ACCESS_TOKEN }}'
         }),
-        terrain = L.tileLayer('https://api.mapbox.com/styles/v1/nijeldev/cjhgodu8f4x4p2smizw2o0btn/tiles/256/{z}/{x}/{y}?access_token={accessToken}', {
-           attribution: mapBoxAttribution,
-           maxZoom: 18,
-           accessToken: '{{ MAPBOX_ACCESS_TOKEN }}'
-       }),
+        terrain = L.tileLayer(mapBoxURL, {
+            attribution: mapBoxAttribution,
+            maxZoom: 18,
+            id: 'mapbox.emerald',
+            accessToken: '{{ MAPBOX_ACCESS_TOKEN }}'
+        }),
         satellite = L.tileLayer(mapBoxURL, {
             attribution: mapBoxAttribution,
             maxZoom: 18,
@@ -87,7 +88,7 @@
             map.addLayer(terrain);
             map.removeLayer(streets);
             map.removeLayer(satellite);
-            layerId = 'terrain';
+            layerId = 'mapbox.emerald';
         } else if (this.id === 'btn2') {
             map.addLayer(streets);
             map.removeLayer(terrain);

--- a/gahtc/mapbuilder/templates/mapbuilder/map-extent.html
+++ b/gahtc/mapbuilder/templates/mapbuilder/map-extent.html
@@ -32,19 +32,19 @@
     map.fitBounds(mapBounds);
 
     var marker = L.marker(center).addTo(map);
-    L.tileLayer('https://api.tiles.mapbox.com/v4/{id}/{z}/{x}/{y}.png?access_token={accessToken}', {
-        attribution: 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, <a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, Imagery © <a href="http://mapbox.com">Mapbox</a>',
-        // maxZoom: 18,
-        id: layerId,
-        accessToken: '{{ MAPBOX_ACCESS_TOKEN }}'
-    }).addTo(map)
+    
+    // L.tileLayer('https://api.tiles.mapbox.com/v4/{id}/{z}/{x}/{y}.png?access_token={accessToken}', {
+    //     attribution: 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, <a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, Imagery © <a href="http://mapbox.com">Mapbox</a>',
+    //     id: layerId,
+    //     accessToken: '{{ MAPBOX_ACCESS_TOKEN }}'
+    // }).addTo(map)
 
     $(document).ready(function () {
-        if (layerId == 'streets') {
+        if (layerId == 'mapbox.light') {
             $("#btn2").trigger('click');
         } else if (layerId == 'terrain') {
             $("#btn1").trigger('click');
-        } else if (layerId == 'satellite') {
+        } else if (layerId == 'mapbox.satellite') {
             $("#btn3").trigger('click');
 
         }
@@ -57,7 +57,7 @@
       var bounds = map.getBounds();
         localStorage.setItem('zoom', map.getZoom());
         localStorage.setItem('bounds', JSON.stringify(bounds));
-});
+    });
 
 
 
@@ -67,12 +67,11 @@
             id: 'mapbox.light',
             accessToken: '{{ MAPBOX_ACCESS_TOKEN }}'
         }),
-        terrain = L.tileLayer(mapBoxURL, {
-            attribution: mapBoxAttribution,
-            maxZoom: 18,
-            id: 'mapbox.emerald',
-            accessToken: '{{ MAPBOX_ACCESS_TOKEN }}'
-        }),
+        terrain = L.tileLayer('https://api.mapbox.com/styles/v1/nijeldev/cjhgodu8f4x4p2smizw2o0btn/tiles/256/{z}/{x}/{y}?access_token={accessToken}', {
+           attribution: mapBoxAttribution,
+           maxZoom: 18,
+           accessToken: '{{ MAPBOX_ACCESS_TOKEN }}'
+       }),
         satellite = L.tileLayer(mapBoxURL, {
             attribution: mapBoxAttribution,
             maxZoom: 18,
@@ -85,19 +84,21 @@
         $('.layer-buttons').removeClass('button-active');
         $(this).addClass('button-active');
         if (this.id === 'btn1') {
-            map.removeLayer(streets, satellite);
             map.addLayer(terrain);
-            layerId = 'mapbox.emerald';
+            map.removeLayer(streets);
+            map.removeLayer(satellite);
+            layerId = 'terrain';
         } else if (this.id === 'btn2') {
-            map.removeLayer(terrain, satellite);
             map.addLayer(streets);
+            map.removeLayer(terrain);
+            map.removeLayer(satellite);
             layerId = 'mapbox.light';
         } else {
-            map.removeLayer(streets, terrain);
             map.addLayer(satellite);
+            map.removeLayer(streets);
+            map.removeLayer(terrain);
             layerId = 'mapbox.satellite';
         }
-
         localStorage.setItem('layerId', layerId);
     });
 </script>

--- a/gahtc/mapbuilder/templates/mapbuilder/map.html
+++ b/gahtc/mapbuilder/templates/mapbuilder/map.html
@@ -32,17 +32,18 @@
     var marker = L.marker([lat, long]).addTo(map);
 
 
-    var streets = L.tileLayer(mapBoxURL, {
+   var streets = L.tileLayer(mapBoxURL, {
             attribution: mapBoxAttribution,
             maxZoom: 18,
             id: 'mapbox.light',
             accessToken: '{{ MAPBOX_ACCESS_TOKEN }}'
         }),
-        terrain = L.tileLayer('https://api.mapbox.com/styles/v1/nijeldev/cjhgodu8f4x4p2smizw2o0btn/tiles/256/{z}/{x}/{y}?access_token={accessToken}', {
-           attribution: mapBoxAttribution,
-           maxZoom: 18,
-           accessToken: '{{ MAPBOX_ACCESS_TOKEN }}'
-       }),
+        terrain = L.tileLayer(mapBoxURL, {
+            attribution: mapBoxAttribution,
+            maxZoom: 18,
+            id: 'mapbox.emerald',
+            accessToken: '{{ MAPBOX_ACCESS_TOKEN }}'
+        }),
         satellite = L.tileLayer(mapBoxURL, {
             attribution: mapBoxAttribution,
             maxZoom: 18,
@@ -57,7 +58,7 @@
             map.addLayer(terrain);
             map.removeLayer(streets);
             map.removeLayer(satellite);
-            layerId = 'terrain';
+            layerId = 'mapbox.emerald';
         } else if (this.id === 'btn2') {
             map.addLayer(streets);
             map.removeLayer(terrain);

--- a/gahtc/mapbuilder/templates/mapbuilder/map.html
+++ b/gahtc/mapbuilder/templates/mapbuilder/map.html
@@ -38,12 +38,11 @@
             id: 'mapbox.light',
             accessToken: '{{ MAPBOX_ACCESS_TOKEN }}'
         }),
-        terrain = L.tileLayer(mapBoxURL, {
-            attribution: mapBoxAttribution,
-            maxZoom: 18,
-            id: 'mapbox.emerald',
-            accessToken: '{{ MAPBOX_ACCESS_TOKEN }}'
-        }),
+        terrain = L.tileLayer('https://api.mapbox.com/styles/v1/nijeldev/cjhgodu8f4x4p2smizw2o0btn/tiles/256/{z}/{x}/{y}?access_token={accessToken}', {
+           attribution: mapBoxAttribution,
+           maxZoom: 18,
+           accessToken: '{{ MAPBOX_ACCESS_TOKEN }}'
+       }),
         satellite = L.tileLayer(mapBoxURL, {
             attribution: mapBoxAttribution,
             maxZoom: 18,
@@ -63,12 +62,12 @@
             map.addLayer(streets);
             map.removeLayer(terrain);
             map.removeLayer(satellite);
-            layerId = 'streets';
+            layerId = 'mapbox.light';
         } else {
             map.addLayer(satellite);
             map.removeLayer(streets);
             map.removeLayer(terrain);
-            layerId = 'satellite';
+            layerId = 'mapbox.satellite';
         }
         localStorage.setItem('layerId', layerId);
     });


### PR DESCRIPTION
### What does this PR do?
This PR resolves the following issues ;
-When a user clicks to save a map with the save button, it's automatically being published to the community index.
-On the map drawing canvas, choosing a fill color reset the fill opacity.
-On the map drawing canvas, the opacity slider doesn't allow shapes to be fully opaque initially after they're drawn. Changing the fill color or line color seems to enable opacity to go higher than 50%.
-On the map drawing canvas, the `edit-icons` and `format-icons` do not become deactivated once activated. If no shape or text is selected, these tools should be deactivated. 
-On the map drawing canvas, hitting the delete key when editing a text element deletes the entire element.
-On the map drawing contain, the `.canvas-container` is taller than the `#map-canvas` and that's adding about 100px of white space below the `#map-canvas` (see attached) .```